### PR TITLE
Adds button to open layermanager

### DIFF
--- a/src/layermanager.js
+++ b/src/layermanager.js
@@ -32,6 +32,20 @@ const Layermanager = function Layermanager(options = {}) {
     }
   });
 
+  const openLayermanagerBtn = Origo.ui.Button({
+    cls: 'round compact primary icon-small margin-x-smaller',
+    click() {
+      viewer.dispatch('active:layermanager');
+    },
+    style: {
+      'align-self': 'center'
+    },
+    icon: '#o_add_24px',
+    iconStyle: {
+      fill: '#fff'
+    }
+  });
+
   const setActive = function setActive() {
     this.render();
   };
@@ -45,6 +59,8 @@ const Layermanager = function Layermanager(options = {}) {
     onAdd(e) {
       viewer = e.target;
       viewer.on('active:layermanager', setActive.bind(this));
+      let legend = viewer.getControlByName('legend');
+      legend.addButtonToTools(openLayermanagerBtn);
       main = Main({ 
         viewer,
         sourceFields,


### PR DESCRIPTION
resolves #3 
Uses `legend.addButtonToTools(button)` to add the button that opens the layermanager GUI.

I have troubles building the plugin, but the code in the commit is identical to a commit used in Eskilstuna-kommun/layermanager-csw (which works).

I do 'npm install' and then 'npm run-script build', but the latter gives errors related to node modules. Not sure why I get the errors after doing an 'npm install' but if anyone tests this, do you get errors as well?